### PR TITLE
fix: remove --prod flag from deploy-dev.yml

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -93,7 +93,6 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          vercel-args: '--prod'
           working-directory: ./
           scope: ${{ secrets.VERCEL_ORG_ID }}
           alias-domains: |


### PR DESCRIPTION
## 🚨 Critical Fix: DEV deploying to PRODUCTION

**deploy-dev.yml was deploying to PRODUCTION instead of DEV**

### ❌ Problema
- ercel-args: '--prod' causaba deployments a producción desde develop
- URL afectada: https://smartroom-rental.vercel.app (producción)

### ✅ Solución
- Eliminada línea ercel-args: '--prod'
- Ahora despliega como preview/development
- Alias correcto: dev.smartroom-rental.vercel.app

### 📋 Cambios
- .github/workflows/deploy-dev.yml (1 línea eliminada)

### ⚠️ Impacto
**CRÍTICO**: Previene deployments accidentales a producción desde develop