### PR TITLE
fix: remove problematic if condition from deploy-dev.yml

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -182,7 +182,6 @@ jobs:
           fi
 
       - name: Send Slack notification
-        if: secrets.SLACK_WEBHOOK_URL != ''
         continue-on-error: true
         uses: 8398a7/action-slack@v3
         with:


### PR DESCRIPTION
## 🔧 Fix: Workflow Syntax Error

GitHub Actions was rejecting the workflow with error:
`
Unrecognized named-value: 'secrets'
`

### ❌ Problema
`yaml
if: secrets.SLACK_WEBHOOK_URL != ''
`

GitHub Actions no acepta esta sintaxis en algunos casos.

### ✅ Solución
Eliminada la condición if ya que el step tiene continue-on-error: true, por lo que fallará silenciosamente si SLACK_WEBHOOK_URL no está configurado.

### 📋 Cambios
- .github/workflows/deploy-dev.yml (1 línea eliminada)

Esto permite que el workflow se ejecute correctamente.