### PR TITLE
fix: remove alias-domains from deploy-dev.yml

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -95,8 +95,6 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           working-directory: ./
           scope: ${{ secrets.VERCEL_ORG_ID }}
-          alias-domains: |
-            dev.smartroom-rental.vercel.app
 
       - name: Run smoke tests against dev
         continue-on-error: true


### PR DESCRIPTION
## 🔧 Fix: Deployment Alias Issue

El deployment a Vercel **se estaba creando exitosamente** pero fallaba al intentar asignar el alias.

### ❌ Problema
`
Error! The deployment is not ready.
`

El workflow intentaba asignar dev.smartroom-rental.vercel.app como alias inmediatamente después del deployment, pero Vercel necesita tiempo para que el deployment esté completamente listo.

### ✅ Solución
Eliminada la configuración lias-domains del workflow. Vercel creará automáticamente una URL de preview para cada deployment.

### 📋 Cambios
- .github/workflows/deploy-dev.yml (2 líneas eliminadas)

### 🚀 Resultado
El deployment ahora completará exitosamente y Vercel generará una URL de preview automáticamente.